### PR TITLE
Remove outdated css file

### DIFF
--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_compare.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_compare.html
@@ -20,8 +20,3 @@
         {% endif %}
     </div>
 {% endblock %}
-
-{% block extra_css %}
-    {{ block.super }}
-    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/compare-revisions.css' %}" type="text/css" />
-{% endblock %}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/compare.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/compare.html
@@ -10,8 +10,3 @@
         {% include "./includes/comparison.html" %}
     </div>
 {% endblock %}
-
-{% block extra_css %}
-    {{ block.super }}
-    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/compare-revisions.css' %}" type="text/css" />
-{% endblock %}


### PR DESCRIPTION
# The problem

When trying to access the "compare revisions" view in a project with `DEBUG=False` and `whitenoise` set up, the view gives a 500 error with the following message:

```
ValueError: Missing staticfiles manifest entry for 'wagtailadmin/css/layouts/compare-revisions.css'
```

# The cause

This issue is caused by the 'wagtailadmin/css/layouts/compare-revisions.css' stylesheet being moved out of the `admin` app and into a `core.css` stylesheet on the `4.0.X` branch. See:
- https://github.com/wagtail/wagtail/blob/stable/4.0.x/client/scss/core.scss#L190
- https://github.com/wagtail/wagtail/blob/stable/4.0.x/client/scss/layouts/_compare-revisions.scss

# The solution

Since `core.scss` is already loaded by default on the admin panel, the 'compare-revisions.css' stylesheet will also be loaded by default on 4+ versions of Wagtail. Hence, we can simply remove the imports for those stylesheets.
