### PR TITLE
Fix Safari JS error accessing `window.external`

### DIFF
--- a/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
+++ b/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
@@ -1,6 +1,6 @@
 (function() {
     // Check if Do Not Track is enabled
-    if (window.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack || (window.external || {}).msTrackingProtectionEnabled) {
+    if (window.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack) {
         if (window.doNotTrack == '1' || navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1' || 'msTrackingProtectionEnabled' in window.external && window.external.msTrackingProtectionEnabled()) {
             // Don't track this browser
             return;

--- a/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
+++ b/wagtail_ab_testing/static/wagtail_ab_testing/js/tracker.js
@@ -1,6 +1,6 @@
 (function() {
     // Check if Do Not Track is enabled
-    if (window.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack || 'msTrackingProtectionEnabled' in window.external) {
+    if (window.doNotTrack || navigator.doNotTrack || navigator.msDoNotTrack || (window.external || {}).msTrackingProtectionEnabled) {
         if (window.doNotTrack == '1' || navigator.doNotTrack == 'yes' || navigator.doNotTrack == '1' || navigator.msDoNotTrack == '1' || 'msTrackingProtectionEnabled' in window.external && window.external.msTrackingProtectionEnabled()) {
             // Don't track this browser
             return;


### PR DESCRIPTION
The `tracker.js` code attempts to honour the "Do Not Track" browser flag, but it's using a [deprecated API](https://developer.mozilla.org/en-US/docs/Web/API/Window/external#browser_compatibility), which has been removed from Safari. Currently it fails with this message:

```
[Error] TypeError: undefined is not an Object. (evaluating ''msTrackingProtectionEnabled' in window.external')
	(anonymous function) (tracker.js:3:114)
	Global Code (tracker.js:137)
```