### PR TITLE
Support Python 3.12 and Django 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,19 +49,19 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         toxenv: ["py"]
         include:
           # Linting
-          - python: "3.11"
+          - python: "3.12"
             toxenv: flake8
             experimental: false
             # Future Wagtail release from main branch (allowed to fail)
-          - python: "3.11"
+          - python: "3.12"
             toxenv: wagtailmain-sqlite
             experimental: true
-          - python: "3.11"
+          - python: "3.12"
             toxenv: wagtailmain-postgres
             experimental: true
     steps:

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ setup(
     install_requires=[
         "Wagtail>=4.1",
         "user-agents>=2.2,<2.3",
-        "numpy>=1.19.4,<1.27",
-        "scipy>=1.5.4,<1.12",
+        "numpy>=1.19.4,<2",
+        "scipy>=1.5.4,<2",
     ],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==1.2.1"],

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
@@ -48,8 +49,8 @@ setup(
     install_requires=[
         "Wagtail>=4.1",
         "user-agents>=2.2,<2.3",
-        "numpy>=1.19.4,<1.25",
-        "scipy>=1.5.4,<1.10",
+        "numpy>=1.19.4,<1.27",
+        "scipy>=1.5.4,<1.12",
     ],
     extras_require={
         "testing": ["dj-database-url==0.5.0", "freezegun==1.2.1"],

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 4",
         "Framework :: Wagtail :: 5",

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{38,39,310}-django{32,40,41}-wagtail{41,42}-{sqlite,postgres}
     py311-django41-wagtail{41,42}-{sqlite,postgres}
     py{38,39,310,311}-django{32,41,42}-wagtail{50,51,52}-{sqlite,postgres}
+    py312-django{42,50}-wagtail52-{sqlite,postgres}
 
 [flake8]
 # E501: Line too long
@@ -22,6 +23,7 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 
 deps =
     coverage
@@ -29,6 +31,7 @@ deps =
     django40: django>=4.0,<4.1
     django41: django>=4.1,<4.2
     django42: django>=4.2,<5
+    django50: django>=5.0,<5.1
 
     wagtail41: wagtail~=4.1
     wagtail42: wagtail~=4.2
@@ -43,7 +46,7 @@ setenv =
     postgres: DATABASE_URL={env:DATABASE_URL:postgres:///wagtail_ab_testing}
 
 [testenv:flake8]
-basepython=python3.11
+basepython=python3.12
 deps=flake8>=2.2.0
 commands=flake8 wagtail_ab_testing
 


### PR DESCRIPTION
- Add Python 3.12 and Django 5.0 to the testing matrix.
- Bump maximum versions of `numpy` and `scipy` to versions that can be installed in Python 3.12.