### PR TITLE
Fix page chooser

### DIFF
--- a/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
+++ b/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
+import getJsonScript from '../../utils/getJsonScript'
 
 // A label element without Wagtail's 'float: left;' rule applied
 const SunkenLabel = styled.label`
@@ -36,8 +37,9 @@ const GoalPageSelector: FunctionComponent<GoalPageSelectorProps> = ({
     // Fetch info about the page whenever the selected page ID is changed
     useEffect(() => {
         if (selectedPageId) {
+            const adminRootUrl = getJsonScript('wagtail-ab-testing-admin-root-url');
             fetch(
-                `${wagtailConfig.ADMIN_ROOT_URL}api/main/pages/${selectedPageId}/`,
+                `${adminRootUrl}api/main/pages/${selectedPageId}/`,
             )
                 .then((response) => response.json())
                 .then(setSelectedPageInfo);
@@ -56,7 +58,7 @@ const GoalPageSelector: FunctionComponent<GoalPageSelectorProps> = ({
     ) => {
         e.preventDefault();
         (window as any).ModalWorkflow({
-            url: (window as any).AB_TESTING_CHOOSE_PAGE_URL,
+            url: getJsonScript("wagtail-ab-testing-choose-page-url"),
             onload: (window as any).PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 pageChosen: function (pageData: any) {

--- a/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
+++ b/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
-import getJsonScript from '../../utils/getJsonScript'
+import getJsonScript from '../../utils/getJsonScript';
 
 // A label element without Wagtail's 'float: left;' rule applied
 const SunkenLabel = styled.label`
@@ -37,10 +37,10 @@ const GoalPageSelector: FunctionComponent<GoalPageSelectorProps> = ({
     // Fetch info about the page whenever the selected page ID is changed
     useEffect(() => {
         if (selectedPageId) {
-            const adminRootUrl = getJsonScript('wagtail-ab-testing-admin-root-url');
-            fetch(
-                `${adminRootUrl}api/main/pages/${selectedPageId}/`,
-            )
+            const adminRootUrl = getJsonScript(
+                'wagtail-ab-testing-admin-root-url',
+            );
+            fetch(`${adminRootUrl}api/main/pages/${selectedPageId}/`)
                 .then((response) => response.json())
                 .then(setSelectedPageInfo);
         } else {
@@ -58,7 +58,7 @@ const GoalPageSelector: FunctionComponent<GoalPageSelectorProps> = ({
     ) => {
         e.preventDefault();
         (window as any).ModalWorkflow({
-            url: getJsonScript("wagtail-ab-testing-choose-page-url"),
+            url: getJsonScript('wagtail-ab-testing-choose-page-url'),
             onload: (window as any).PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 pageChosen: function (pageData: any) {

--- a/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
+++ b/wagtail_ab_testing/static_src/components/GoalSelector/index.tsx
@@ -56,7 +56,7 @@ const GoalPageSelector: FunctionComponent<GoalPageSelectorProps> = ({
     ) => {
         e.preventDefault();
         (window as any).ModalWorkflow({
-            url: (window as any).chooserUrls.pageChooser,
+            url: (window as any).AB_TESTING_CHOOSE_PAGE_URL,
             onload: (window as any).PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 pageChosen: function (pageData: any) {

--- a/wagtail_ab_testing/static_src/custom.d.ts
+++ b/wagtail_ab_testing/static_src/custom.d.ts
@@ -14,8 +14,6 @@ declare global {
     // Wagtail globals
 
     interface WagtailConfig {
-        ADMIN_ROOT_URL: string;
-
         ADMIN_API: {
             PAGES: string;
             DOCUMENTS: string;

--- a/wagtail_ab_testing/static_src/utils/getJsonScript.tsx
+++ b/wagtail_ab_testing/static_src/utils/getJsonScript.tsx
@@ -1,7 +1,7 @@
 export default (id: string) => {
     const element = document.getElementById(id);
-    if(! element) {
+    if (!element) {
         throw Error(`Element ${id} not found`);
     }
     return JSON.parse(element.textContent!);
-}
+};

--- a/wagtail_ab_testing/static_src/utils/getJsonScript.tsx
+++ b/wagtail_ab_testing/static_src/utils/getJsonScript.tsx
@@ -1,0 +1,7 @@
+export default (id: string) => {
+    const element = document.getElementById(id);
+    if(! element) {
+        throw Error(`Element ${id} not found`);
+    }
+    return JSON.parse(element.textContent!);
+}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
@@ -31,12 +31,10 @@
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ goal_selector_props|json_script:"data-goal-selector-props" }}
-    <script>
-        {% url 'wagtailadmin_home' as wagtailadmin_root_url %}
-        wagtailConfig.ADMIN_ROOT_URL = '{{ wagtailadmin_root_url|escapejs }}';
-        {% url 'wagtailadmin_choose_page' as wagtailadmin_choose_page_url %}
-        window.AB_TESTING_CHOOSE_PAGE_URL = '{{ wagtailadmin_choose_page_url|escapejs }}';
-    </script>
+    {% url 'wagtailadmin_home' as wagtailadmin_root_url %}
+    {{ wagtailadmin_root_url|json_script:"wagtail-ab-testing-admin-root-url" }}
+    {% url 'wagtailadmin_choose_page' as wagtailadmin_choose_page_url %}
+    {{ wagtailadmin_choose_page_url|json_script:"wagtail-ab-testing-choose-page-url" }}
     <script src="{% url 'wagtail_ab_testing_admin:javascript_catalog' %}"></script>
     <script type="text/javascript" src="{% versioned_static 'wagtailadmin/js/page-chooser-modal.js' %}"></script>
     <script src="{% versioned_static 'wagtail_ab_testing/js/wagtail-ab-testing.js' %}"></script>

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
@@ -34,6 +34,8 @@
     <script>
         {% url 'wagtailadmin_home' as wagtailadmin_root_url %}
         wagtailConfig.ADMIN_ROOT_URL = '{{ wagtailadmin_root_url|escapejs }}';
+        {% url 'wagtailadmin_choose_page' as wagtailadmin_choose_page_url %}
+        window.AB_TESTING_CHOOSE_PAGE_URL = '{{ wagtailadmin_choose_page_url|escapejs }}';
     </script>
     <script src="{% url 'wagtail_ab_testing_admin:javascript_catalog' %}"></script>
     <script type="text/javascript" src="{% versioned_static 'wagtailadmin/js/page-chooser-modal.js' %}"></script>


### PR DESCRIPTION
Refs. https://github.com/wagtail-nest/wagtail-ab-testing/issues/84#issuecomment-2250067278

`chooserUrls.pageChooser` has been removed in Wagtail 6.1: https://docs.wagtail.org/en/stable/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers