### PR TITLE
Page template for SimplePage

### DIFF
--- a/wagtail_ab_testing/test/templates/wagtail_ab_testing_test/simple_page.html
+++ b/wagtail_ab_testing/test/templates/wagtail_ab_testing_test/simple_page.html
@@ -1,0 +1,5 @@
+{% load wagtail_ab_testing_tags %}
+
+<h1>{{ page.title }}</h1>
+
+{% wagtail_ab_testing_script %}


### PR DESCRIPTION
The test app (`python testmanage.py runserver`) is useful for qucik tests in development. It would be even more useful if the test page could be opened in the browser, to simulate an A/B test.