### PR TITLE
Add Wagtail 7.0 to test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
-    ; Wagtail 5.2 LTS
+    ; Django 4.2 LTS is the only version still supported under Wagtail 5.2
     py{39,310,311,312}-django42-wagtail52-{sqlite,postgres}
-    py{310,311,312}-django50-wagtail52-{sqlite,postgres}
-    ; Wagtail 6.1 + 6.2
-    py{39,310,311,312}-django42-wagtail{61,62}-{sqlite,postgres}
-    py{310,311,312}-django50-wagtail{61,62}-{sqlite,postgres}
-    py{310,311,312,313}-django51-wagtail63-{sqlite,postgres}
+    py{39,310,311,312}-django42-wagtail{63,64,70}-{sqlite,postgres}
+    py{310,311,312,313}-django51-wagtail{63,64,70}-{sqlite,postgres}
+    ; 6.3 LTS and 7.0 are the only versions to support Django 5.2 as of now
+    py{310,311,312,313}-django52-wagtail{63,70}-{sqlite,postgres}
 
 [testenv]
 allowlist_externals = coverage
@@ -21,13 +20,12 @@ basepython =
 deps =
     coverage
     django42: django>=4.2,<5
-    django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
 
     wagtail52: wagtail~=5.2.0
-    wagtail61: wagtail~=6.1.0
-    wagtail62: wagtail~=6.2.0
     wagtail63: wagtail~=6.3.0
+    wagtail64: wagtail~=6.4.0
+    wagtail70: wagtail>=7.0rc1,<8.0
 
     postgres: psycopg2>=2.9
 extras = testing


### PR DESCRIPTION
>Stop testing against unsupported versions of Wagtail and Django in an
> attempt to keep testing matrix combinations under control.