### PR TITLE
Fix Cloudflare Worker cookie name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ export default {
                 // Participants of a test would have a cookie that tells us which
                 // version of the page being tested on that they should see
                 // If they don't have this cookie, serve a random version
-                const versionCookieName = `abtesting-${testId}-version`;
+                const versionCookieName = `wagtail-ab-testing_${testId}_version`;
                 const cookie = request.headers.get('cookie');
                 let version;
                 if (cookie && cookie.includes(`${versionCookieName}=control`)) {


### PR DESCRIPTION
This was fixed elsewhere in the project in https://github.com/wagtail-nest/wagtail-ab-testing/pull/34 - but looks like the README wasn't updated.

Honest disclaimer - I haven't tested this worker Javascript code, it's just something I noticed whilst working on something else!