### PR TITLE
Replace `wagtailadmin/pages/_editor_js.html` include

### DIFF
--- a/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/add_form.html
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block extra_js %}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {% hook_output 'insert_editor_js' %}
     {{ goal_selector_props|json_script:"data-goal-selector-props" }}
     {% url 'wagtailadmin_home' as wagtailadmin_root_url %}
     {{ wagtailadmin_root_url|json_script:"wagtail-ab-testing-admin-root-url" }}

--- a/wagtail_ab_testing/templates/wagtail_ab_testing/results.html
+++ b/wagtail_ab_testing/templates/wagtail_ab_testing/results.html
@@ -123,7 +123,7 @@
 {% endblock %}
 
 {% block extra_js %}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {% hook_output 'insert_editor_js' %}
     <script src="{% url 'wagtail_ab_testing_admin:javascript_catalog' %}"></script>
     <script type="text/javascript" src="{% versioned_static 'wagtailadmin/js/page-chooser-modal.js' %}"></script>
     <script src="{% versioned_static 'wagtail_ab_testing/js/wagtail-ab-testing.js' %}"></script>


### PR DESCRIPTION
Template was deprecated and removed in Wagtail 8.0.